### PR TITLE
Feast beta

### DIFF
--- a/feast/DetectionModules/abstract_detection_method.py
+++ b/feast/DetectionModules/abstract_detection_method.py
@@ -164,8 +164,12 @@ class DetectionMethod:
             params['max'] = [params['max']]
         condition_allowed = False
         for ind in range(len(params['min'])):
-            if params['min'][ind] <= condition <= params['max'][ind]:
-                condition_allowed = True
+            if params['min'][ind] > params['max'][ind]:
+                if ~(params['max'][ind] <= condition <= params['min'][ind]):
+                    condition_allowed = True
+            else:
+                if params['min'][ind] <= condition <= params['max'][ind]:
+                    condition_allowed = True
         return condition_allowed
 
     @staticmethod

--- a/feast/DetectionModules/ldar_program.py
+++ b/feast/DetectionModules/ldar_program.py
@@ -39,11 +39,24 @@ class LDARProgram:
         :param gas_field: the simulation gas_field object
         :return:
         """
-        for tech in self.tech_dict.values():
-            if hasattr(tech, 'survey_interval') and tech.survey_interval \
-                    and np.mod(time.current_time, tech.survey_interval) < time.delta_t:
-                tech.action(list(np.linspace(0, gas_field.n_sites - 1, gas_field.n_sites, dtype=int)))
-            tech.detect(time, gas_field, self.emissions.get_current_emissions(time))
+        for i, tech in enumerate(self.tech_dict.values()):
+            # Check for tiered detection
+            if (len(self.tech_dict.values()) > 1) and (i >= 1):
+                det_ct = self.tech_dict[list(self.tech_dict.keys())[i - 1]].detection_count.time_value
+                if len(det_ct) > 0:
+                    det_ct_time = det_ct[-1][0]
+                else:
+                    det_ct_time = None
+                if (det_ct_time == time.current_time) or (det_ct_time is not None):
+                    if hasattr(tech, 'survey_interval') and tech.survey_interval \
+                            and np.mod(time.current_time, tech.survey_interval) < time.delta_t:
+                        tech.action(list(np.linspace(0, gas_field.n_sites - 1, gas_field.n_sites, dtype=int)))
+                    tech.detect(time, gas_field, self.emissions.get_current_emissions(time))
+            else:
+                if hasattr(tech, 'survey_interval') and tech.survey_interval \
+                        and np.mod(time.current_time, tech.survey_interval) < time.delta_t:
+                    tech.action(list(np.linspace(0, gas_field.n_sites - 1, gas_field.n_sites, dtype=int)))
+                tech.detect(time, gas_field, self.emissions.get_current_emissions(time))
         for rep in self.repair.values():
             rep.repair(time, self.emissions)
 

--- a/feast/DetectionModules/repair.py
+++ b/feast/DetectionModules/repair.py
@@ -38,7 +38,10 @@ class Repair:
             rep_cond = emissions.emissions.reparable & emissions.emissions.index.isin(self.to_repair) & \
                        (emissions.emissions.end_time > time.current_time + self.repair_delay)
             emissions.emissions.loc[rep_cond, 'end_time'] = time.current_time + self.repair_delay
-            self.repair_count.append_entry([time.current_time + self.repair_delay, int(np.sum(rep_cond))])
+            time_cond = emissions.emissions['start_time'] >= emissions.emissions['end_time']
+            emissions.emissions.loc[time_cond, 'start_time'] = emissions.emissions.loc[time_cond, 'end_time']
+            self.repair_count.append_entry([time.current_time + self.repair_delay,
+                                            len(emissions.emissions.loc[rep_cond].index.unique())])
             self.repair_cost.append_entry([time.current_time + self.repair_delay,
                                            np.sum(emissions.emissions.loc[rep_cond, 'repair_cost'])])
             self.to_repair = []

--- a/feast/EmissionSimModules/infrastructure_classes.py
+++ b/feast/EmissionSimModules/infrastructure_classes.py
@@ -250,6 +250,8 @@ class GasField:
                     met_conds[parameter_name] = np.min(relevant_metdat)
                 elif interp_mode.lower() == 'median':
                     met_conds[parameter_name] = np.median(relevant_metdat)
+                elif interp_mode.lower() == 'random':
+                    met_conds[parameter_name] = np.random.choice(relevant_metdat)
                 else:
                     raise ValueError("Invalid meteorological data type.")
         return met_conds

--- a/feast/EmissionSimModules/simulation_classes.py
+++ b/feast/EmissionSimModules/simulation_classes.py
@@ -65,7 +65,10 @@ class Scenario:
         [lp.calc_rep_costs(self.time) for lp in self.ldar_program_dict.values()]
 
         # -------------- Save results --------------
-        self.save(dir_out, method=save_method)
+        if save_method == 'object':
+            return self.ldar_program_dict
+        else:
+            self.save(dir_out, method=save_method)
 
     def save(self, dir_out, method='json'):
         """


### PR DESCRIPTION

    -  Repair count no longer over-counts repairs
    -  Wind direction ranges can now include 0 degrees
    -  Tiered detection programs no longer erroneously dispatch follow-up programs
    -  Added "random" interp_mode functionality for LDAR programs
    -  Allow for the direct passing of results objects from FEAST
